### PR TITLE
Square Root macro

### DIFF
--- a/src/togos/noise2/function/SqrtDa_Da.java
+++ b/src/togos/noise2/function/SqrtDa_Da.java
@@ -1,0 +1,46 @@
+package togos.noise2.function;
+
+import togos.noise2.data.DataDa;
+import togos.noise2.data.DataDaDaDa;
+import togos.noise2.lang.FunctionUtil;
+import togos.noise2.rewrite.ExpressionRewriter;
+
+public class SqrtDa_Da extends TNLFunctionDaDaDa_Da implements FunctionDaDaDa_Da {
+	
+	private FunctionDaDaDa_Da arg;
+	
+	public SqrtDa_Da( FunctionDaDaDa_Da arg) {
+		this.arg = arg;
+	}
+	
+	public DataDa apply( DataDaDaDa in) {
+		int len = in.getLength();
+		double[] dat = arg.apply(in).x;
+		double[] out = new double[len];
+		for (int i = 0; i < len; i++) {
+			out[i] = dat[i] > 0 ? Math.sqrt(dat[i]) : 0;
+		}
+		return new DataDa( out );
+	}
+	
+	public String toString() {
+		return "sqrt(" + arg + ")";
+	}
+
+	public String toTnl() { 
+		return "sqrt(" + FunctionUtil.toTnl(arg) + ")"; 
+	}
+
+	public boolean isConstant() { 
+		return FunctionUtil.isConstant(arg); 
+	}
+
+	public Object[] directSubExpressions() {
+		return new Object[]{ arg };
+    }
+
+	public Object rewriteSubExpressions( ExpressionRewriter rw ) {
+	    return new SqrtDa_Da((FunctionDaDaDa_Da)rw.rewrite(arg));
+    }
+
+}

--- a/src/togos/noise2/lang/macro/NoiseMacros.java
+++ b/src/togos/noise2/lang/macro/NoiseMacros.java
@@ -25,6 +25,7 @@ import togos.noise2.function.PerlinDaDaDa_Da;
 import togos.noise2.function.RidgeOutDaDaDa_Da;
 import togos.noise2.function.ScaleInDaDaDa_Da;
 import togos.noise2.function.SimplexDaDaDa_Da;
+import togos.noise2.function.SqrtDa_Da;
 import togos.noise2.function.SubtractOutDaDaDa_Da;
 import togos.noise2.function.TransformInDaDaDa_Da;
 import togos.noise2.function.TranslateInDaDaDa_Da;
@@ -96,6 +97,15 @@ public class NoiseMacros
 		add("*", dddaamt(MultiplyOutDaDaDa_Da.class));
 		add("-", dddaamt(SubtractOutDaDaDa_Da.class));
 		add("/", dddaamt(DivideOutDaDaDa_Da.class));
+
+		add("sqrt", new BaseMacroType() {
+			protected int getRequiredArgCount() { return 1; }
+
+			protected Object instantiate(ASTNode node, ASTNode[] argNodes, Object[] compiledArgs) throws CompileError {
+				return new SqrtDa_Da(FunctionUtil.toDaDaDa_Da(compiledArgs[0], argNodes[0]));
+			}
+		}
+		);
 		
 		// Clamping/folding
 		add("min", dddaamt(MinOutDaDaDa_Da.class));

--- a/test/togos/noise2/function/SqrtTest.java
+++ b/test/togos/noise2/function/SqrtTest.java
@@ -1,0 +1,26 @@
+package togos.noise2.function;
+
+import togos.noise2.data.DataDa;
+import togos.noise2.data.DataDaDaDa;
+import togos.noise2.lang.ScriptError;
+
+public class SqrtTest extends NoiseFunctionTest {
+
+	public void testSqrt() throws ScriptError {
+
+		DataDaDaDa in = new DataDaDaDa(
+			new double[]{ -1, 0, 1, 4 },
+			new double[]{  0, 0, 0, 0 },
+			new double[]{  0, 0, 0, 0 }
+		);
+
+		FunctionDaDaDa_Da expr = 
+			(FunctionDaDaDa_Da) comp.compile("sqrt(x)","test-script");
+
+		DataDa out = expr.apply(in);
+		assertEquals(0, out.x[0] );
+		assertEquals(0, out.x[1] );
+		assertEquals(1, out.x[2] );
+		assertEquals(2, out.x[3] );
+	}
+}


### PR DESCRIPTION
I added a square root macro, sqrt, useful for creating cones and hemispheres (and hopefully other stuff).

```
#cone
layer( materials.stone, 0, (100 - sqrt( (x * x) + (z * z) ) ) )

#hemisphere
layer( materials.sand, 0, sqrt(10000 - (x * x) - (z * z)) )
```
